### PR TITLE
Fix decoding of entities in XML

### DIFF
--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -77,7 +77,9 @@ module Opscode
       end
 
       def new_value?(document, xpath, value_to_check)
-        XPath.first(document, xpath).to_s != value_to_check.to_s
+        old_value = XPath.first(document, xpath)
+        return old_value.value != value_to_check.to_s unless old_value.nil?
+        '' != value_to_check.to_s
       end
 
       def new_or_empty_value?(document, xpath, value_to_check)

--- a/spec/unit/libraries/helper_spec.rb
+++ b/spec/unit/libraries/helper_spec.rb
@@ -1,0 +1,44 @@
+module Windows
+  module Helper
+  end
+end
+
+require_relative '../../../libraries/helper'
+require 'rexml/document'
+
+class Test
+  include Opscode::IIS::Helper
+end
+
+describe Opscode::IIS::Helper do
+  let(:doc) do
+    REXML::Document.new(xml)
+  end
+
+  shared_examples 'unchanged value' do
+    it 'should return false' do
+      test = Test.new
+      expect(test.new_value?(doc.root, '@value', new_value)).to be_falsy
+    end
+  end
+
+  describe '#new_value?' do
+    context 'when attribute is nil' do
+      let(:xml) { '<test/>' }
+      let(:new_value) { nil }
+      it_should_behave_like 'unchanged value'
+    end
+
+    context 'when attribut is "t&st"' do
+      let(:xml) { '<test value="t&amp;st"/>' }
+      let(:new_value) { 't&st' }
+      it_should_behave_like 'unchanged value'
+    end
+
+    context 'when attribut is ""' do
+      let(:xml) { '<test value=""/>' }
+      let(:new_value) { '' }
+      it_should_behave_like 'unchanged value'
+    end
+  end
+end


### PR DESCRIPTION
This patch properly escapes entities / attributes values when read and compared to expected value in resource.